### PR TITLE
tests: fix - sometimes wrong language in tests 

### DIFF
--- a/src/test/java/io/inisos/bank4j/validator/constraintvalidators/BICValidatorTest.java
+++ b/src/test/java/io/inisos/bank4j/validator/constraintvalidators/BICValidatorTest.java
@@ -9,6 +9,8 @@ import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
+
+import java.util.Locale;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -19,6 +21,7 @@ class BICValidatorTest {
 
     @BeforeAll
     public static void setUpValidator() {
+        Locale.setDefault(Locale.ENGLISH);
         ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
         validator = factory.getValidator();
     }

--- a/src/test/java/io/inisos/bank4j/validator/constraintvalidators/IBANValidatorTest.java
+++ b/src/test/java/io/inisos/bank4j/validator/constraintvalidators/IBANValidatorTest.java
@@ -9,6 +9,8 @@ import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
+
+import java.util.Locale;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -19,6 +21,7 @@ class IBANValidatorTest {
 
     @BeforeAll
     public static void setUpValidator() {
+        Locale.setDefault(Locale.ENGLISH);
         ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
         validator = factory.getValidator();
     }


### PR DESCRIPTION
Hi,

We expect errors in English as we test after them. But right now I'm getting this error:
```
org.opentest4j.AssertionFailedError: expected: <must be a valid IBAN> but was: <doit être un IBAN valide>
```

This PR forces the locale to English