### PR TITLE
fix: 12h → 24h clock in FORMAT_AS_ID (hh → HH)

### DIFF
--- a/src/main/java/io/inisos/bank4j/impl/JAXBCreditTransferV03.java
+++ b/src/main/java/io/inisos/bank4j/impl/JAXBCreditTransferV03.java
@@ -26,7 +26,7 @@ import java.util.*;
  */
 public class JAXBCreditTransferV03 implements CreditTransferOperation {
 
-    private static final DateTimeFormatter FORMAT_AS_ID = DateTimeFormatter.ofPattern("yyyyMMddhhmmss");
+    private static final DateTimeFormatter FORMAT_AS_ID = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
 
     private final Priority instructionPriority;
     private final String serviceLevelCode;

--- a/src/main/java/io/inisos/bank4j/impl/JAXBCreditTransferV03Ch02.java
+++ b/src/main/java/io/inisos/bank4j/impl/JAXBCreditTransferV03Ch02.java
@@ -31,7 +31,7 @@ import java.util.StringJoiner;
  */
 public class JAXBCreditTransferV03Ch02 implements CreditTransferOperation {
 
-    private static final DateTimeFormatter FORMAT_AS_ID = DateTimeFormatter.ofPattern("yyyyMMddhhmmss");
+    private static final DateTimeFormatter FORMAT_AS_ID = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
     private static final String SCHEMA_LOCATION = "http://www.six-interbank-clearing.com/de/pain.001.001.03.ch.02.xsd";
 
     private final Priority instructionPriority;

--- a/src/main/java/io/inisos/bank4j/impl/JAXBCreditTransferV09.java
+++ b/src/main/java/io/inisos/bank4j/impl/JAXBCreditTransferV09.java
@@ -26,7 +26,7 @@ import java.util.*;
  */
 public class JAXBCreditTransferV09 implements CreditTransferOperation {
 
-    private static final DateTimeFormatter FORMAT_AS_ID = DateTimeFormatter.ofPattern("yyyyMMddhhmmss");
+    private static final DateTimeFormatter FORMAT_AS_ID = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
 
     private final Priority instructionPriority;
     private final String serviceLevelCode;

--- a/src/main/java/io/inisos/bank4j/impl/JAXBSepaCreditTransfer003V03.java
+++ b/src/main/java/io/inisos/bank4j/impl/JAXBSepaCreditTransfer003V03.java
@@ -30,7 +30,7 @@ import java.util.StringJoiner;
  */
 public class JAXBSepaCreditTransfer003V03 implements CreditTransferOperation {
 
-    private static final DateTimeFormatter FORMAT_AS_ID = DateTimeFormatter.ofPattern("yyyyMMddhhmmss");
+    private static final DateTimeFormatter FORMAT_AS_ID = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
     private static final String DEFAULT_SERVICE_LEVEL = "SEPA";
     private static final String CURRENCY_EUR = "EUR";
 


### PR DESCRIPTION
`hh` (12-hour) in FORMAT_AS_ID causes duplicate MsgId/PmtInfId for times
12 hours apart (e.g. 02:30 and 14:30). Banks may reject such duplicates.