### PR TITLE
fix: reject mixed-currency transactions to prevent invalid CtrlSum

### DIFF
--- a/src/main/java/io/inisos/bank4j/impl/JAXBCreditTransferV03.java
+++ b/src/main/java/io/inisos/bank4j/impl/JAXBCreditTransferV03.java
@@ -61,7 +61,7 @@ public class JAXBCreditTransferV03 implements CreditTransferOperation {
         this.serviceLevelCode = serviceLevelCode;
         this.debtor = debtor;
         this.debtorAccount = Objects.requireNonNull(debtorAccount, "Debtor account cannot be null");
-        this.transactions = requireTransaction(Objects.requireNonNull(transactions));
+        this.transactions = requireSingleCurrency(requireTransaction(Objects.requireNonNull(transactions)));
         this.creationDateTime = Optional.ofNullable(creationDateTime).orElse(LocalDateTime.now());
         this.requestedExecutionDate = Optional.ofNullable(requestedExecutionDate).orElse(LocalDate.now().plusDays(1));
         this.id = Optional.ofNullable(id).orElseGet(() -> FORMAT_AS_ID.format(this.creationDateTime));
@@ -340,6 +340,17 @@ public class JAXBCreditTransferV03 implements CreditTransferOperation {
     private <T> Collection<T> requireTransaction(Collection<T> collection) {
         if (collection.isEmpty()) {
             throw new IllegalArgumentException("At least 1 transaction is required");
+        }
+        return collection;
+    }
+
+    private Collection<Transaction> requireSingleCurrency(Collection<Transaction> collection) {
+        long distinctCurrencies = collection.stream()
+                .map(Transaction::getCurrencyCode)
+                .distinct()
+                .count();
+        if (distinctCurrencies > 1) {
+            throw new IllegalArgumentException("All transactions must have the same currency");
         }
         return collection;
     }

--- a/src/main/java/io/inisos/bank4j/impl/JAXBCreditTransferV03Ch02.java
+++ b/src/main/java/io/inisos/bank4j/impl/JAXBCreditTransferV03Ch02.java
@@ -67,7 +67,7 @@ public class JAXBCreditTransferV03Ch02 implements CreditTransferOperation {
         this.serviceLevelCode = serviceLevelCode;
         this.debtor = debtor;
         this.debtorAccount = Objects.requireNonNull(debtorAccount, "Debtor account cannot be null");
-        this.transactions = requireTransaction(Objects.requireNonNull(transactions));
+        this.transactions = requireSingleCurrency(requireTransaction(Objects.requireNonNull(transactions)));
         this.creationDateTime = Optional.ofNullable(creationDateTime).orElse(LocalDateTime.now());
         this.requestedExecutionDate = Optional.ofNullable(requestedExecutionDate).orElse(LocalDate.now().plusDays(1));
         this.id = Optional.ofNullable(id).orElseGet(() -> FORMAT_AS_ID.format(this.creationDateTime));
@@ -370,6 +370,17 @@ public class JAXBCreditTransferV03Ch02 implements CreditTransferOperation {
     private <T> Collection<T> requireTransaction(Collection<T> collection) {
         if (collection.isEmpty()) {
             throw new IllegalArgumentException("At least 1 transaction is required");
+        }
+        return collection;
+    }
+
+    private Collection<Transaction> requireSingleCurrency(Collection<Transaction> collection) {
+        long distinctCurrencies = collection.stream()
+                .map(Transaction::getCurrencyCode)
+                .distinct()
+                .count();
+        if (distinctCurrencies > 1) {
+            throw new IllegalArgumentException("All transactions must have the same currency");
         }
         return collection;
     }

--- a/src/main/java/io/inisos/bank4j/impl/JAXBCreditTransferV09.java
+++ b/src/main/java/io/inisos/bank4j/impl/JAXBCreditTransferV09.java
@@ -73,7 +73,7 @@ public class JAXBCreditTransferV09 implements CreditTransferOperation {
         this.serviceLevelCode = serviceLevelCode;
         this.debtor = debtor;
         this.debtorAccount = Objects.requireNonNull(debtorAccount, "Debtor account cannot be null");
-        this.transactions = requireTransaction(Objects.requireNonNull(transactions));
+        this.transactions = requireSingleCurrency(requireTransaction(Objects.requireNonNull(transactions)));
         this.creationDateTime = Optional.ofNullable(creationDateTime).orElse(LocalDateTime.now());
         if(requestedExecutionDate != null && requestedExecutionDateTime != null) {
             throw new IllegalArgumentException("You cannot specify both requestedExecutionDate and requestedExecutionDateTime");
@@ -376,6 +376,17 @@ public class JAXBCreditTransferV09 implements CreditTransferOperation {
     private <T> Collection<T> requireTransaction(Collection<T> collection) {
         if (collection.isEmpty()) {
             throw new IllegalArgumentException("At least 1 transaction is required");
+        }
+        return collection;
+    }
+
+    private Collection<Transaction> requireSingleCurrency(Collection<Transaction> collection) {
+        long distinctCurrencies = collection.stream()
+                .map(Transaction::getCurrencyCode)
+                .distinct()
+                .count();
+        if (distinctCurrencies > 1) {
+            throw new IllegalArgumentException("All transactions must have the same currency");
         }
         return collection;
     }


### PR DESCRIPTION
## Problem

`getTotalAmount()` adds up all transaction amounts regardless of currency.
The result is used as `CtrlSum` in the PAIN.001 XML header — a value banks use
to verify that the sum of all individual amounts matches. With mixed currencies
(e.g. 8 EUR + 15 JPY) the control sum is meaningless and the payment file
may be rejected.

`JAXBSepaCreditTransfer003V03` was already safe because it enforces EUR-only
via `requireEurCurrency()`. V03, V09 and V03Ch02 had no such guard.

## Fix

Added `requireSingleCurrency()` in the three affected classes, called in the
constructor right after the existing `requireTransaction()` check.

Throws `IllegalArgumentException` early if transactions contain more than one
distinct currency code — consistent with the existing validation style.