### PR TITLE
Migrate IBAN validation to iban-commons

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Easily generate XML Credit Transfers based on [ISO 20022](https://www.iso20022.o
 
 Provides IBAN, BIC and Character set (for reference elements) validation with annotations.
 
-Using JAXB and [iban4j](https://github.com/arturmkrtchyan/iban4j).
+Using JAXB and [iban-commons](https://github.com/SpeedBankingDe/iban-commons).
 
 ## Installation
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <java.version>11</java.version>
 
         <!-- Dependency versions -->
-        <iban4j.version>3.2.13-RELEASE</iban4j.version>
+        <iban-commons.version>1.8.7</iban-commons.version>
         <jakarta-validation-api.version>3.1.1</jakarta-validation-api.version>
         <jakarta-xml-bind-api.version>4.0.5</jakarta-xml-bind-api.version>
         <jaxb-runtime.version>4.0.7</jaxb-runtime.version>
@@ -59,11 +59,11 @@
 
     <dependencies>
 
-        <!-- iban4j -->
+        <!-- iban-commons: Zero-dependency, high-performance Java 8+ library for IBAN and BIC validation -->
         <dependency>
-            <groupId>org.iban4j</groupId>
-            <artifactId>iban4j</artifactId>
-            <version>${iban4j.version}</version>
+            <groupId>de.speedbanking</groupId>
+            <artifactId>iban-commons</artifactId>
+            <version>${iban-commons.version}</version>
         </dependency>
 
         <!-- JAXB -->

--- a/src/main/java/io/inisos/bank4j/impl/JAXBCreditTransferV03.java
+++ b/src/main/java/io/inisos/bank4j/impl/JAXBCreditTransferV03.java
@@ -1,13 +1,13 @@
 package io.inisos.bank4j.impl;
 
+import de.speedbanking.bic.Bic;
+import de.speedbanking.iban.Iban;
 import io.inisos.bank4j.*;
 import iso._20022.pain_001_001_03.*;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Marshaller;
-import org.iban4j.BicUtil;
-import org.iban4j.IbanUtil;
 
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
@@ -213,7 +213,7 @@ public class JAXBCreditTransferV03 implements CreditTransferOperation {
 
     private Optional<BranchAndFinancialInstitutionIdentification4> optionalBranchAndFinancialInstitutionIdentificationOpt(BankAccount bankAccount) {
         return bankAccount.getBic().map(bic -> {
-            BicUtil.validate(bic);
+            Bic.validate(bic); // throws InvalidBicException for invalid BIC
             FinancialInstitutionIdentification7 financialInstitutionIdentification = new FinancialInstitutionIdentification7();
             financialInstitutionIdentification.setBIC(bic);
             BranchAndFinancialInstitutionIdentification4 branchAndFinancialInstitutionIdentification = new BranchAndFinancialInstitutionIdentification4();
@@ -226,7 +226,7 @@ public class JAXBCreditTransferV03 implements CreditTransferOperation {
         BranchAndFinancialInstitutionIdentification4 branchAndFinancialInstitutionIdentification = new BranchAndFinancialInstitutionIdentification4();
         FinancialInstitutionIdentification7 financialInstitutionIdentification = new FinancialInstitutionIdentification7();
         bankAccount.getBic().ifPresent(bic -> {
-            BicUtil.validate(bic);
+            Bic.validate(bic);
             financialInstitutionIdentification.setBIC(bic);
         });
         branchAndFinancialInstitutionIdentification.setFinInstnId(financialInstitutionIdentification);
@@ -270,7 +270,7 @@ public class JAXBCreditTransferV03 implements CreditTransferOperation {
         Optional<String> optionalOtherId = bankAccount.getOtherId();
         if (optionalIban.isPresent()) {
             String iban = optionalIban.get();
-            IbanUtil.validate(iban);
+            Iban.validate(iban); // throws InvalidIbanException for invalid IBAN
             accountIdentification.setIBAN(iban);
         } else if (optionalOtherId.isPresent()) {
             GenericAccountIdentification1 genericAccountIdentification = new GenericAccountIdentification1();

--- a/src/main/java/io/inisos/bank4j/impl/JAXBCreditTransferV03Ch02.java
+++ b/src/main/java/io/inisos/bank4j/impl/JAXBCreditTransferV03Ch02.java
@@ -1,13 +1,13 @@
 package io.inisos.bank4j.impl;
 
+import de.speedbanking.bic.Bic;
+import de.speedbanking.iban.Iban;
 import io.inisos.bank4j.*;
 import iso._20022.pain_001_001_03_ch_02.*;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Marshaller;
-import org.iban4j.BicUtil;
-import org.iban4j.IbanUtil;
 
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
@@ -208,7 +208,7 @@ public class JAXBCreditTransferV03Ch02 implements CreditTransferOperation {
 
     private Optional<BranchAndFinancialInstitutionIdentification4CH> optionalBranchAndFinancialInstitutionIdentificationOpt(BankAccount bankAccount) {
         return bankAccount.getBic().map(bic -> {
-            BicUtil.validate(bic);
+            Bic.validate(bic); // throws InvalidBicException for invalid BIC
             FinancialInstitutionIdentification7CH financialInstitutionIdentification = new FinancialInstitutionIdentification7CH();
             financialInstitutionIdentification.setBIC(bic);
             BranchAndFinancialInstitutionIdentification4CH branchAndFinancialInstitutionIdentification = new BranchAndFinancialInstitutionIdentification4CH();
@@ -221,7 +221,7 @@ public class JAXBCreditTransferV03Ch02 implements CreditTransferOperation {
         BranchAndFinancialInstitutionIdentification4CHBicOrClrId branchAndFinancialInstitutionIdentification = new BranchAndFinancialInstitutionIdentification4CHBicOrClrId();
         FinancialInstitutionIdentification7CHBicOrClrId financialInstitutionIdentification = new FinancialInstitutionIdentification7CHBicOrClrId();
         bankAccount.getBic().ifPresent(bic -> {
-            BicUtil.validate(bic);
+            Bic.validate(bic);
             financialInstitutionIdentification.setBIC(bic);
         });
         branchAndFinancialInstitutionIdentification.setFinInstnId(financialInstitutionIdentification);
@@ -296,7 +296,7 @@ public class JAXBCreditTransferV03Ch02 implements CreditTransferOperation {
         Optional<String> optionalOtherId = bankAccount.getOtherId();
         if (optionalIban.isPresent()) {
             String iban = optionalIban.get();
-            IbanUtil.validate(iban);
+            Iban.validate(iban);
             accountIdentification.setIBAN(iban);
         } else if (optionalOtherId.isPresent()) {
             GenericAccountIdentification1CH genericAccountIdentification = new GenericAccountIdentification1CH();

--- a/src/main/java/io/inisos/bank4j/impl/JAXBCreditTransferV09.java
+++ b/src/main/java/io/inisos/bank4j/impl/JAXBCreditTransferV09.java
@@ -1,13 +1,13 @@
 package io.inisos.bank4j.impl;
 
+import de.speedbanking.bic.Bic;
+import de.speedbanking.iban.Iban;
 import io.inisos.bank4j.*;
 import iso._20022.pain_001_001_09.*;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Marshaller;
-import org.iban4j.BicUtil;
-import org.iban4j.IbanUtil;
 
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
@@ -241,7 +241,7 @@ public class JAXBCreditTransferV09 implements CreditTransferOperation {
 
     private Optional<BranchAndFinancialInstitutionIdentification6> optionalBranchAndFinancialInstitutionIdentificationOpt(BankAccount bankAccount) {
         return bankAccount.getBic().map(bic -> {
-            BicUtil.validate(bic);
+            Bic.validate(bic); // throws InvalidBicException for invalid BIC
             FinancialInstitutionIdentification18 financialInstitutionIdentification = new FinancialInstitutionIdentification18();
             financialInstitutionIdentification.setBICFI(bic);
             BranchAndFinancialInstitutionIdentification6 branchAndFinancialInstitutionIdentification = new BranchAndFinancialInstitutionIdentification6();
@@ -254,7 +254,7 @@ public class JAXBCreditTransferV09 implements CreditTransferOperation {
         BranchAndFinancialInstitutionIdentification6 branchAndFinancialInstitutionIdentification = new BranchAndFinancialInstitutionIdentification6();
         FinancialInstitutionIdentification18 financialInstitutionIdentification = new FinancialInstitutionIdentification18();
         bankAccount.getBic().ifPresent(bic -> {
-            BicUtil.validate(bic);
+            Bic.validate(bic);
             financialInstitutionIdentification.setBICFI(bic);
         });
         branchAndFinancialInstitutionIdentification.setFinInstnId(financialInstitutionIdentification);
@@ -306,7 +306,7 @@ public class JAXBCreditTransferV09 implements CreditTransferOperation {
         Optional<String> optionalOtherId = bankAccount.getOtherId();
         if (optionalIban.isPresent()) {
             String iban = optionalIban.get();
-            IbanUtil.validate(iban);
+            Iban.validate(iban);
             accountIdentification.setIBAN(iban);
         } else if (optionalOtherId.isPresent()) {
             GenericAccountIdentification1 genericAccountIdentification = new GenericAccountIdentification1();

--- a/src/main/java/io/inisos/bank4j/impl/JAXBSepaCreditTransfer003V03.java
+++ b/src/main/java/io/inisos/bank4j/impl/JAXBSepaCreditTransfer003V03.java
@@ -1,13 +1,13 @@
 package io.inisos.bank4j.impl;
 
+import de.speedbanking.bic.Bic;
+import de.speedbanking.iban.Iban;
 import io.inisos.bank4j.*;
 import iso._20022.pain_001_003_03.*;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Marshaller;
-import org.iban4j.BicUtil;
-import org.iban4j.IbanUtil;
 
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
@@ -209,7 +209,7 @@ public class JAXBSepaCreditTransfer003V03 implements CreditTransferOperation {
 
     private Optional<BranchAndFinancialInstitutionIdentificationSEPA1> optionalBranchAndFinancialInstitutionIdentificationOpt(BankAccount bankAccount) {
         return bankAccount.getBic().map(bic -> {
-            BicUtil.validate(bic);
+            Bic.validate(bic); // throws InvalidBicException for invalid BIC
             FinancialInstitutionIdentificationSEPA1 financialInstitutionIdentification = new FinancialInstitutionIdentificationSEPA1();
             financialInstitutionIdentification.setBIC(bic);
             BranchAndFinancialInstitutionIdentificationSEPA1 branchAndFinancialInstitutionIdentification = new BranchAndFinancialInstitutionIdentificationSEPA1();
@@ -221,10 +221,10 @@ public class JAXBSepaCreditTransfer003V03 implements CreditTransferOperation {
     private BranchAndFinancialInstitutionIdentificationSEPA3 mandatoryBranchAndFinancialInstitutionIdentification(BankAccount bankAccount) {
         BranchAndFinancialInstitutionIdentificationSEPA3 branchAndFinancialInstitutionIdentification = new BranchAndFinancialInstitutionIdentificationSEPA3();
         FinancialInstitutionIdentificationSEPA3 financialInstitutionIdentification = new FinancialInstitutionIdentificationSEPA3();
-        Optional<String> bic = bankAccount.getBic();
-        if (bic.isPresent()) {
-            BicUtil.validate(bic.get());
-            financialInstitutionIdentification.setBIC(bic.get());
+        if (bankAccount.getBic().isPresent()) {
+            String bic = bankAccount.getBic().get();
+            Bic.validate(bic);
+            financialInstitutionIdentification.setBIC(bic);
         } else {
             OthrIdentification othrIdentification = new OthrIdentification();
             othrIdentification.setId(OthrIdentificationCode.NOTPROVIDED);
@@ -282,7 +282,7 @@ public class JAXBSepaCreditTransfer003V03 implements CreditTransferOperation {
         Optional<String> optionalIban = bankAccount.getIban();
         if (optionalIban.isPresent()) {
             String iban = optionalIban.get();
-            IbanUtil.validate(iban);
+            Iban.validate(iban);
             accountIdentification.setIBAN(iban);
         } else {
             throw new IllegalArgumentException("IBAN must be provided for pain.001.003.03");

--- a/src/main/java/io/inisos/bank4j/validator/constraintvalidators/BICValidator.java
+++ b/src/main/java/io/inisos/bank4j/validator/constraintvalidators/BICValidator.java
@@ -1,25 +1,22 @@
 package io.inisos.bank4j.validator.constraintvalidators;
 
+import de.speedbanking.bic.Bic;
 import io.inisos.bank4j.validator.constraints.BIC;
+
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
-import org.iban4j.BicUtil;
-import org.iban4j.Iban4jException;
 
+/**
+ * Validator implementation for the {@link BIC} constraint.
+ * <p>
+ * This validator checks if a given string is a syntactically valid Business Identifier Code (BIC).
+ * It supports optional values by returning {@code true} for {@code null} or empty strings.
+ */
 public class BICValidator implements ConstraintValidator<BIC, String> {
 
     @Override
     public boolean isValid(String value, ConstraintValidatorContext constraintValidatorContext) {
-        if (value != null && value.length() != 0) {
-            try {
-                BicUtil.validate(value);
-                return true;
-            } catch (Iban4jException e) {
-                return false;
-            }
-        } else {
-            return true;
-        }
+        return value == null || value.isEmpty() || Bic.isValid(value);
     }
 
 }

--- a/src/main/java/io/inisos/bank4j/validator/constraintvalidators/IBANValidator.java
+++ b/src/main/java/io/inisos/bank4j/validator/constraintvalidators/IBANValidator.java
@@ -1,25 +1,22 @@
 package io.inisos.bank4j.validator.constraintvalidators;
 
+import de.speedbanking.iban.Iban;
 import io.inisos.bank4j.validator.constraints.IBAN;
+
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
-import org.iban4j.Iban4jException;
-import org.iban4j.IbanUtil;
 
+/**
+ * Validator implementation for the {@link IBAN} constraint.
+ * <p>
+ * This validator checks if a given string is a syntactically valid International Bank Account Number (IBAN).
+ * It supports optional values by returning {@code true} for {@code null} or empty strings.
+ */
 public class IBANValidator implements ConstraintValidator<IBAN, String> {
 
     @Override
     public boolean isValid(String value, ConstraintValidatorContext constraintValidatorContext) {
-        if (value != null && value.length() != 0) {
-            try {
-                IbanUtil.validate(value);
-                return true;
-            } catch (Iban4jException e) {
-                return false;
-            }
-        } else {
-            return true;
-        }
+        return value == null || value.isEmpty() || Iban.isValid(value);
     }
 
 }


### PR DESCRIPTION
This PR introduces `iban-commons` in favor of `iban4j`. [`iban-commons`](https://www.speedbanking.de/) has demonstrated to be superior in terms of performance, allocation (GC pressure), country coverage etc.
The internal validation logic in `IBANValidator` has been refactored for better performance and readability.

- replace iban4j dependency with iban-commons v1.8.6
- update IBANValidator to use de.speedbanking.iban.Iban
- simplify isValid logic in BIC/IBANValidator using short-circuit evaluation
- remove obsolete exception handling for Iban4jException

I am an author of the `iban-commons` library ([GitHub](https://github.com/SpeedBankingDe/iban-commons)).